### PR TITLE
Improve many things for our item parsing

### DIFF
--- a/models/Item.py
+++ b/models/Item.py
@@ -1,6 +1,5 @@
 import logging
 import copy
-import timeit
 from attr import attrs
 from .item_modifier import ItemModifier
 from utils.trade import get_ninja_bases

--- a/models/Item.py
+++ b/models/Item.py
@@ -1,13 +1,12 @@
+import logging
 from attr import attrs
-
 from .item_modifier import ItemModifier
-
 
 @attrs(auto_attribs=True)
 class Item:
     rarity: str = 'Rare'
-    name: str = 'Pseudo'
-    base: str = 'Pseudo'
+    name: str = None
+    base: str = None
 
     quality: int = 0
     # TODO: handle base stats
@@ -15,17 +14,32 @@ class Item:
 
     raw_sockets: str = ''
     # Item level/ Map tier
-    iLevel: int = 0
+    ilevel: int = 0
 
-    # TODO: support map IIQ, IIR, pack size
     modifiers: [(ItemModifier, str)] = []
     corrupted: bool = False
     mirrored: bool = False
 
-    # TODO: handle influence types, as an enum?
+    # A list of influences that affect the item.
     influence: [str] = []
 
+    def __iter__(self):
+        for attr, value in self.__dict__.items():
+            yield attr, value
+
+    def print_attributes(self, label = "Item"):
+        logging.debug("====== %s ======" % label)
+        for k, v in self:
+            logging.debug("%s: %s" % (k, v))
+        logging.debug("====== End of %s ======" % label)
+
+    def print_class(self):
+        self.print_attributes("Item")
+
     def __attrs_post_init__(self):
+        if not self.base:
+            self.base = self.name
+            self.name = None
         sockets = self.raw_sockets.lower()
         self.r_sockets = sockets.count('r')
         self.b_sockets = sockets.count('b')
@@ -35,8 +49,74 @@ class Item:
         # R-R-R-R R-R is not incorrectly registered as 5 link
         self.links = sockets.count('-') - sockets.count(' ') + 1
 
+        if str(self.__class__.__name__) == "Item":
+            self.print_attributes()
+
     def get_pseudo_mods(self):
         raise NotImplementedError
 
     def get_json(self):
+        raise NotImplementedError
+
+@attrs(auto_attribs=True)
+class Map(Item):
+    iiq: int = 0
+    iir: int = 0
+    pack_size: int = 0
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        super().print_attributes("Map")
+
+    def get_json(self):
+        data = super().get_json()
+        # Fill data with more json fields as needed.
+        raise NotImplementedError
+
+@attrs(auto_attribs=True)
+class Prophecy(Item):
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        super().print_attributes("Prophecy")
+
+    def get_json(self):
+        data = super().get_json()
+        # Fill data with more json fields as needed.
+        raise NotImplementedError
+
+@attrs(auto_attribs=True)
+class Fragment(Item):
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        super().print_attributes("Fragment")
+
+    def get_json(self):
+        data = super().get_json()
+        # Fill data with more json fields as needed.
+        raise NotImplementedError
+
+@attrs(auto_attribs=True)
+class Organ(Item):
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        super().print_attributes("Organ")
+
+    def get_json(self):
+        data = super().get_json()
+        # Fill data with more json fields as needed.
+        raise NotImplementedError
+
+@attrs(auto_attribs=True)
+class Flask(Item):
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        super().print_attributes("Flask")
+
+    def get_json(self):
+        data = super().get_json()
+        # Fill data with more json fields as needed.
         raise NotImplementedError

--- a/models/Item.py
+++ b/models/Item.py
@@ -1,47 +1,71 @@
 import logging
 import copy
+import re
 from attr import attrs
 from .item_modifier import ItemModifier
-from utils.trade import get_ninja_bases
+from enums.item_modifier_type import ItemModifierType
+from utils.trade import (
+    get_ninja_bases,
+    get_item_modifiers_by_text,
+    search_url,
+    exchange_url
+)
 
-NINJA_BASES = []
-TYPES = {}
+# A global type cache for Base -> Item derivative conversions
+types = dict()
+
+def set_modifiers(json_data, modifiers):
+    '''
+    :param json_data: Root json dictionary to set modifiers of
+    :param modifiers: List of modifiers
+    :return: Altered json dictionary
+    '''
+
+    # Temporary hack. This is allowing us to search up mods with values
+    # that we store separated by commas, like Adds # to # Physical Damage.
+    mods = []
+    for e in modifiers:
+        if ',' in e[1]:
+            value = re.sub(r',.*', '', e[1])
+            mods.append({ "id": e[0].id, "value": { "min": int(value) }})
+        else:
+            mods.append({ "id": e[0].id, "value": { "min": int(e[1]) }})
+
+    '''
+    mods = [
+        {
+            "id": e[0].id,
+            "value": {
+                "min": int(e[1]) if ',' not in e[1] else e[1]
+            }
+        } for e in modifiers
+    ]
+    '''
+    json_data["query"]["stats"][0]["filters"] = mods
+    return json_data
 
 @attrs(auto_attribs=True)
 class Item:
-    rarity: str = 'Rare'
+    rarity: str = 'rare'
     name: str = None
     base: str = None
-
+    ilevel: int = 0
     quality: int = 0
+
     # TODO: handle base stats
     stats: [str] = []
 
     raw_sockets: str = ''
-    # Item level/ Map tier
-    ilevel: int = 0
 
     modifiers: [(ItemModifier, str)] = []
     corrupted: bool = False
     mirrored: bool = False
+    veiled: bool = False
 
     # A list of influences that affect the item.
     influence: [str] = []
 
-    links: [int] = 0
-
-    def __iter__(self):
-        for attr, value in self.__dict__.items():
-            yield attr, value
-
-    def print_attributes(self, label = "Item"):
-        logging.debug("====== %s ======" % label)
-        for k, v in self:
-            logging.debug("%s: %s" % (k, v))
-        logging.debug("====== End of %s ======" % label)
-
-    def print_class(self):
-        self.print_attributes("Item")
+    links: int = 0
 
     def __attrs_post_init__(self):
         if not self.base:
@@ -52,16 +76,33 @@ class Item:
         self.b_sockets = sockets.count('b')
         self.g_sockets = sockets.count('g')
         self.w_sockets = sockets.count('w')
-        self.a_sockets = sockets.count('a')  # abyssal
+        self.a_sockets = sockets.count('a') # Abyssal sockets
         # R-R-R-R R-R is not incorrectly registered as 5 link
         self.links = sockets.count('-') - sockets.count(' ') + 1
 
-        if str(self.__class__.__name__) == "Item":
-            self.print_attributes()
+        if self.base.startswith("Veiled"):
+            self.veiled = True
+
+        # Some debug logging of the attributes of our class. If we are
+        # not running with DEBUG logging enabled, this becomes a no-op
+        if logging.getLogger().getEffectiveLevel() == logging.DEBUG:
+            logging.debug("====== %s ======" % self.__class__.__name__)
+            for k, v in self.__dict__.items():
+                logging.debug("%s: %s" % (k, v))
+            logging.debug("====== End of %s ======" % self.__class__.__name__)
+
+    def sanitize_modifiers(self):
+        '''
+        This method normally allows subclasses of Item to specifically
+        sanitize modifiers. It is also needed within the base class, so
+        that we can call it on any derivative without checking.
+
+        :return: None
+        '''
+        pass
 
     def deduce_specific_object(self):
-        # If we're already a different object, we will not perform this
-        # conversion.
+        # If we're already a different object, turn this into a no-op method
         if str(self.__class__.__name__) != "Item":
             return self
 
@@ -91,21 +132,21 @@ class Item:
             "Quiver": Quiver,
         }
 
-        global TYPES
-        if len(TYPES) == 0:
+        global types
+        if len(types) == 0:
             ninja_bases = get_ninja_bases()
             for e in ninja_bases:
                 item_type = e["type"]
                 item_base = e["base"]
-                if item_base in TYPES:
+                if item_base in types:
                     continue
                 if item_type in weapon_types:
-                    TYPES[item_base] = Weapon
+                    types[item_base] = Weapon
                 elif item_type in other_types:
-                    TYPES[item_base] = other_types[item_type]
+                    types[item_base] = other_types[item_type]
 
-        if self.base in TYPES:
-            cls = TYPES[self.base]
+        if self.base in types:
+            cls = types[self.base]
             logging.debug(
                 "Found base's type and converted the Item to %s" % cls.__class__.__name__
             )
@@ -124,139 +165,403 @@ class Item:
         raise NotImplementedError
 
     def get_json(self):
-        raise NotImplementedError
+        '''
+        This method is the root of all json production for items. It only
+        concerns itself with fields that the majority of subclasses use.
+
+        :return: json data for the Item base class
+        '''
+        data = {
+            "query": {
+                "status": {
+                    "option": "online"
+                },
+
+                "stats": [
+                    {
+                        "type": "and",
+                        "filters": []
+                    }
+                ],
+            },
+            "sort": {
+                "price": "asc"
+            }
+        }
+
+        if self.rarity == "unique" and self.name is not None:
+            data["query"]["name"] = self.name
+
+        if self.base:
+            data["query"]["type"] = self.base
+
+        if len(self.modifiers) > 0:
+            set_modifiers(data, self.modifiers)
+
+        # If we have 6 sockets, we'll include that in the query
+        data["query"]["filters"] = {}
+
+        # Get a total count of sockets on this item
+        sockets = self.r_sockets + self.g_sockets + self.b_sockets
+        sockets += self.w_sockets + self.a_sockets
+
+        # In most items, the only time a price really differs is
+        # when an item is 6 socketed vs not 6 socketed. For this
+        # reason, we'll only set the socket filter when we realize
+        # that an item has 6 sockets
+        if sockets == 6:
+            data["query"]["filters"]["socket_filters"] = {
+                "filters": {
+                    "sockets": {
+                        "min": 6,
+                        "max": 6
+                    }
+                }
+            }
+
+        # If we have 5 or more links, we'll include that in the query
+        if self.links >= 5:
+            data["query"]["filters"]["socket_filters"]["filters"]["links"] = {
+                "min": self.links,
+                "max": self.links
+            }
+
+        # Set this key up; if it's not further modified, that's okay
+        # from the API's perspective
+        data["query"]["filters"]["misc_filters"] = {
+            "filters": {}
+        }
+
+        for influence in self.influence:
+            text = "%s_item" % influence
+            data["query"]["filters"]["misc_filters"]["filters"][text] = {
+                "option": "true"
+            }
+
+        if self.corrupted:
+            data["query"]["filters"]["misc_filters"]["filters"]["corrupted"] = {
+                "option": "true"
+            }
+
+        if self.mirrored:
+            data["query"]["filters"]["misc_filters"]["filters"]["mirrored"] = {
+                "option": "true"
+            }
+
+        if self.veiled:
+            data["query"]["filters"]["misc_filters"]["filters"]["veiled"] = {
+                "option": "true"
+            }
+
+        # Figure out if we should set identified to false for our query json
+        explicit_mods = [
+            mod for mod in self.modifiers
+            if mod[0].type == ItemModifierType.EXPLICIT
+        ]
+        unidentifiable = ('magic', 'rare', 'unique')
+        if len(explicit_mods) == 0 and self.rarity in unidentifiable:
+            data["query"]["filters"]["misc_filters"]["filters"]["identified"] = {
+                "option": "false"
+            }
+
+        return data
 
 @attrs(auto_attribs=True)
-class Map(Item):
+class Searchable(Item):
+    def query_url(self, league):
+        '''
+        :param league: Path of Exile league to format the query URL with
+        :return: A formatted string of the PoE search trade API endpoint
+        '''
+        return search_url(league)
+
+@attrs(auto_attribs=True)
+class Exchangeable(Item):
+    # A conversion table for different types of bases
+    convert = {
+        "Chaos Orb": "chaos",
+        "Exalted Orb": "exa",
+        "Mirror of Kalandra": "mir",
+    }
+
+    def get_json(self):
+        base = self.base
+        if base in self.convert:
+            base = self.convert[self.base]
+
+        data = {
+            "exchange": {
+                "status": {
+                    "option": "online"
+                },
+                "have": ["chaos"],
+                "want": [base.lower().replace(' ', '-')]
+            }
+        }
+        return data
+
+    def query_url(self, league):
+        '''
+        :param league: Path of Exile league to format the query URL with
+        :return: A formatted string of the PoE exchange trade API endpoint
+        '''
+        return exchange_url(league)
+
+@attrs(auto_attribs=True)
+class Wearable(Searchable):
+    def get_json(self):
+        data = super().get_json()
+        data["query"]["filters"]["misc_filters"]["filters"]["ilvl"] = {
+            "min": self.ilevel
+        }
+        return data
+
+@attrs(auto_attribs=True)
+class Currency(Exchangeable): pass
+
+@attrs(auto_attribs=True)
+class Card(Searchable): pass
+
+@attrs(auto_attribs=True)
+class Gem(Searchable):
+    def get_json(self):
+        data = super().get_json()
+        data["query"]["filters"]["misc_filters"]["filters"]["gem_level"] = {
+            "min": self.ilevel
+        }
+        data["query"]["filters"]["misc_filters"]["filters"]["quality"] = {
+            "min": self.quality
+        }
+        return data
+
+# TODO: Implement this.
+@attrs(auto_attribs=True)
+class Beast(Searchable): pass
+
+@attrs(auto_attribs=True)
+class Map(Searchable):
     iiq: int = 0
     iir: int = 0
     pack_size: int = 0
 
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
-        super().print_attributes("Map")
-
     def get_json(self):
         data = super().get_json()
-        # Fill data with more json fields as needed.
-        raise NotImplementedError
+
+        data["query"]["filters"]["map_filters"] = {
+            "filters": {
+                "map_iiq": {
+                    "min": self.iiq
+                },
+                "map_iir": {
+                    "min": self.iir
+                },
+                "map_packsize": {
+                    "min": self.pack_size
+                },
+                "map_tier": {
+                    "min": self.ilevel,
+                    "max": self.ilevel
+                }
+            }
+        }
+
+        # If it's a blighted map, we'll include the blighted filter
+        if self.base.startswith("Blighted"):
+            data["query"]["filters"]["map_filters"]["filters"]["map_blighted"] = {
+                "option": "true"
+            }
+            data["query"]["type"] = {
+                "option": self.base.replace("Blighted ", '')
+            }
+        else:
+            data["query"]["type"] = {
+                "option": self.base
+            }
+
+        # Override the mods in json with just implicits; we do this
+        # to carry over guardian/conqueror influences of a map
+        mods = [
+            mod for mod in self.modifiers
+            if mod[0].type == ItemModifierType.IMPLICIT
+        ]
+        set_modifiers(data, mods)
+
+        return data
 
 @attrs(auto_attribs=True)
-class Prophecy(Item):
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
-        super().print_attributes("Prophecy")
-
+class Prophecy(Searchable):
     def get_json(self):
         data = super().get_json()
-        # Fill data with more json fields as needed.
-        raise NotImplementedError
+        data["query"]["name"] = self.base
+        data["query"]["type"] = "Prophecy"
+        return data
 
 @attrs(auto_attribs=True)
-class Fragment(Item):
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
-        super().print_attributes("Fragment")
-
-    def get_json(self):
-        data = super().get_json()
-        # Fill data with more json fields as needed.
-        raise NotImplementedError
+class Fragment(Searchable): pass
 
 @attrs(auto_attribs=True)
-class Organ(Item):
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
-        super().print_attributes("Organ")
-
+class Organ(Searchable):
     def get_json(self):
+        '''
+        In this subclass override, we carry over the stats produced by
+        it's base, and produce a new JSON dictionary more specific to
+        a Metamorph Organ.
+
+        :return: POST query json data for a Metamorph Organ
+        '''
         data = super().get_json()
-        # Fill data with more json fields as needed.
-        raise NotImplementedError
+        data = {
+            "query": {
+                "type": "Metamorph " + self.base.split(' ')[-1],
+                "stats": data["query"]["stats"],
+                "filters": {
+                    "misc_filters": {
+                        "filters": {
+                            "ilvl": {
+                                "min": self.ilevel
+                            }
+                        }
+                    }
+                }
+            },
+            "sort": {
+                "price": "asc"
+            }
+        }
+        return data
 
 @attrs(auto_attribs=True)
-class Flask(Item):
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
-        super().print_attributes("Flask")
+class Flask(Searchable):
+    name_prefixes = '|'.join([
+        "Small",
+        "Medium",
+        "Large",
+        "Greater",
+        "Grand",
+        "Giant",
+        "Colossal",
+        "Sacred",
+        "Hallowed",
+        "Sanctified",
+        "Divine",
+        "Eternal",
+    ])
 
-    def get_json(self):
-        data = super().get_json()
-        # Fill data with more json fields as needed.
-        raise NotImplementedError
+    def __attrs_post_init__(self):
+        '''
+        An extension of __attrs_post_init__ for the Flask subclass.
+        Flasks have different layouts when copied, as the name is also
+        included in the item's base field. In this extended override,
+        we call the base class original method, then fix up self.base
+        as needed for non-unique flasks.
+
+        :return: None
+        '''
+        super().__attrs_post_init__()
+        if self.rarity != "unique":
+            # Extract the actual flask base out, and use it as the base
+            # we search for. Since we also provide explicit modifiers
+            # when performing the lookup, we will not miss prefixes
+            # or suffixes.
+            match = re.findall(
+                r"([a-zA-Z']+ )?((?!%s)?[ ]?.+ Flask)( .*)?" % self.name_prefixes,
+                self.base
+            )
+            self.base = match[0][1]
+
+            logging.debug("Flask regex matches: %s" % str(match))
+            logging.debug("Deduced flask base: %s" % str(self.base))
 
 ''' Specific Items '''
 @attrs(auto_attribs=True)
-class Accessory(Item):
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
-
-        if str(self.__class__.__name__) == "Accessory":
-            super().print_attributes("Accessory")
-
-    def get_json(self):
-        data = super().get_json()
-        # Fill data with more json fields as needed.
-        raise NotImplementedError
+class Accessory(Wearable): pass
 
 @attrs(auto_attribs=True)
-class Ring(Accessory):
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
-        super().print_attributes("Ring")
-
+class Ring(Accessory): pass
 
 @attrs(auto_attribs=True)
-class Amulet(Accessory):
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
-        super().print_attributes("Ring")
+class Amulet(Accessory): pass
 
 @attrs(auto_attribs=True)
-class Belt(Accessory):
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
-        super().print_attributes("Ring")
+class Belt(Accessory): pass
+
+# Base class for any Armor-type Items located below this class
+@attrs(auto_attribs=True)
+class Armor(Wearable):
+    def sanitize_modifiers(self):
+        '''
+        Sanitize modifiers for an Armor base or subclass. With these items,
+        we should convert certain global modifiers to local modifiers if we
+        find them. This method modifies our modifiers attribute in-place.
+
+        :return: None
+        '''
+        convert = [
+            r'# to maximum (Energy Shield|Armou?r|Evasion Rating)',
+            r'#% increased (Armour|Evasion( Rating)?|Energy Shield)(, .*)?( and )?(.*)?',
+            r'# to (Armou?r|Energy Shield|Evasion Rating)',
+        ]
+
+        for i in range(len(self.modifiers)):
+            for possible in convert:
+                mod = self.modifiers[i]
+                mod_text = mod[0].text
+                mod_type = mod[0].type
+                print("Sanitizing %s" % str(mod))
+                if re.search(possible, mod_text):
+                    altered = mod_text + " (Local)"
+                    sanitized_mod = get_item_modifiers_by_text((altered, mod_type))
+                    self.modifiers[i] = (sanitized_mod, mod[1])
+                    print("Altered mod to be local: %s" % str(self.modifiers[i]))
+                else:
+                    print("No sanitization needed")
 
 @attrs(auto_attribs=True)
-class Helmet(Item):
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
-        super().print_attributes("Helmet")
+class Helmet(Armor): pass
 
 @attrs(auto_attribs=True)
-class BodyArmor(Item):
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
-        super().print_attributes("BodyArmor")
+class BodyArmor(Armor): pass
 
 @attrs(auto_attribs=True)
-class Boots(Item):
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
-        super().print_attributes("Boots")
+class Boots(Armor): pass
 
 @attrs(auto_attribs=True)
-class Gloves(Item):
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
-        super().print_attributes("Gloves")
+class Gloves(Armor): pass
 
 @attrs(auto_attribs=True)
-class Shield(Item):
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
-        super().print_attributes("Shield")
+class Shield(Armor): pass
 
 @attrs(auto_attribs=True)
-class Quiver(Item):
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
-        super().print_attributes("Quiver")
+class Quiver(Wearable): pass
 
 @attrs(auto_attribs=True)
-class Weapon(Item):
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
-        super().print_attributes("Weapon")
+class Weapon(Wearable):
+    def sanitize_modifiers(self):
+        '''
+        Sanitize modifiers for an Weapon base or subclass. With these items,
+        we should convert certain global modifiers to local modifiers if we
+        find them. This method modifies our modifiers attribute in-place.
+
+        :return: None
+        '''
+        convert = [
+            r'increased Attack Speed',
+            r'Adds # to # (.*) Damage',
+            r'# to Accuracy Rating',
+            r'#% chance to Poison on Hit',
+        ]
+
+        for i in range(len(self.modifiers)):
+            for possible in convert:
+                mod = self.modifiers[i]
+                mod_text = mod[0].text
+                mod_type = mod[0].type
+                print("Sanitizing %s" % str(mod))
+                if re.search(possible, mod_text):
+                    altered = mod_text + " (Local)"
+                    sanitized_mod = get_item_modifiers_by_text((altered, mod_type))
+                    self.modifiers[i] = (sanitized_mod, mod[1])
+                    print("Altered mod to be local: %s" % str(self.modifiers[i]))
+                else:
+                    print("No sanitization needed")
 

--- a/models/Item.py
+++ b/models/Item.py
@@ -1,6 +1,12 @@
 import logging
+import copy
+import timeit
 from attr import attrs
 from .item_modifier import ItemModifier
+from utils.trade import get_ninja_bases
+
+NINJA_BASES = []
+TYPES = {}
 
 @attrs(auto_attribs=True)
 class Item:
@@ -22,6 +28,8 @@ class Item:
 
     # A list of influences that affect the item.
     influence: [str] = []
+
+    links: [int] = 0
 
     def __iter__(self):
         for attr, value in self.__dict__.items():
@@ -52,6 +60,67 @@ class Item:
         if str(self.__class__.__name__) == "Item":
             self.print_attributes()
 
+    def deduce_specific_object(self):
+        # If we're already a different object, we will not perform this
+        # conversion.
+        if str(self.__class__.__name__) != "Item":
+            return self
+
+        weapon_types = {
+            "One Handed Sword",
+            "Two Handed Sword",
+            "One Handed Axe",
+            "Two Handed Axe",
+            "One Handed Mace",
+            "Two Handed Mace",
+            "Staff",
+            "Wand",
+            "Claw",
+            "Bow",
+            "Dagger",
+        }
+
+        other_types = {
+            "Helmet": Helmet,
+            "Body Armour": BodyArmor,
+            "Boots": Boots,
+            "Gloves": Gloves,
+            "Ring": Ring,
+            "Amulet": Amulet,
+            "Belt": Belt,
+            "Shield": Shield,
+            "Quiver": Quiver,
+        }
+
+        global TYPES
+        if len(TYPES) == 0:
+            ninja_bases = get_ninja_bases()
+            for e in ninja_bases:
+                item_type = e["type"]
+                item_base = e["base"]
+                if item_base in TYPES:
+                    continue
+                if item_type in weapon_types:
+                    TYPES[item_base] = Weapon
+                elif item_type in other_types:
+                    TYPES[item_base] = other_types[item_type]
+
+        if self.base in TYPES:
+            cls = TYPES[self.base]
+            logging.debug(
+                "Found base's type and converted the Item to %s" % cls.__class__.__name__
+            )
+            kwargs = copy.copy(self.__dict__)
+            for k in ("r_sockets", "b_sockets", "g_sockets", "w_sockets", "a_sockets"):
+                del kwargs[k]
+            return cls(**kwargs)
+
+        logging.error(
+            "deduce_specific_object was called via Item, "
+            + "but no base could be found to be converted"
+        )
+        return self
+
     def get_pseudo_mods(self):
         raise NotImplementedError
 
@@ -75,7 +144,6 @@ class Map(Item):
 
 @attrs(auto_attribs=True)
 class Prophecy(Item):
-
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
         super().print_attributes("Prophecy")
@@ -87,7 +155,6 @@ class Prophecy(Item):
 
 @attrs(auto_attribs=True)
 class Fragment(Item):
-
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
         super().print_attributes("Fragment")
@@ -99,7 +166,6 @@ class Fragment(Item):
 
 @attrs(auto_attribs=True)
 class Organ(Item):
-
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
         super().print_attributes("Organ")
@@ -111,7 +177,6 @@ class Organ(Item):
 
 @attrs(auto_attribs=True)
 class Flask(Item):
-
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
         super().print_attributes("Flask")
@@ -120,3 +185,79 @@ class Flask(Item):
         data = super().get_json()
         # Fill data with more json fields as needed.
         raise NotImplementedError
+
+''' Specific Items '''
+@attrs(auto_attribs=True)
+class Accessory(Item):
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+
+        if str(self.__class__.__name__) == "Accessory":
+            super().print_attributes("Accessory")
+
+    def get_json(self):
+        data = super().get_json()
+        # Fill data with more json fields as needed.
+        raise NotImplementedError
+
+@attrs(auto_attribs=True)
+class Ring(Accessory):
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        super().print_attributes("Ring")
+
+
+@attrs(auto_attribs=True)
+class Amulet(Accessory):
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        super().print_attributes("Ring")
+
+@attrs(auto_attribs=True)
+class Belt(Accessory):
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        super().print_attributes("Ring")
+
+@attrs(auto_attribs=True)
+class Helmet(Item):
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        super().print_attributes("Helmet")
+
+@attrs(auto_attribs=True)
+class BodyArmor(Item):
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        super().print_attributes("BodyArmor")
+
+@attrs(auto_attribs=True)
+class Boots(Item):
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        super().print_attributes("Boots")
+
+@attrs(auto_attribs=True)
+class Gloves(Item):
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        super().print_attributes("Gloves")
+
+@attrs(auto_attribs=True)
+class Shield(Item):
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        super().print_attributes("Shield")
+
+@attrs(auto_attribs=True)
+class Quiver(Item):
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        super().print_attributes("Quiver")
+
+@attrs(auto_attribs=True)
+class Weapon(Item):
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        super().print_attributes("Weapon")
+

--- a/models/item_modifier.py
+++ b/models/item_modifier.py
@@ -2,9 +2,9 @@ from attr import attrib, attrs
 
 from enums.item_modifier_type import ItemModifierType
 
-
-@attrs(auto_attribs=True)
+@attrs(auto_attribs=True, frozen=True)
 class ItemModifier:
     type: ItemModifierType
     id: str
     text: str
+

--- a/parse.py
+++ b/parse.py
@@ -1,3 +1,4 @@
+import timeit
 import logging
 import sys
 import re
@@ -897,7 +898,9 @@ def price_item(text):
     """
     try:
         item = parse_item_info(text)
-        logging.info("Object parsed: %s" % str(item.__class__.__name__))
+        item = item.deduce_specific_object()
+
+        logging.debug("Object type deduced: %s" % str(item.__class__.__name__))
         trade_info = None
         json = None
 

--- a/parse.py
+++ b/parse.py
@@ -1,4 +1,3 @@
-import timeit
 import logging
 import sys
 import re

--- a/utils/trade.py
+++ b/utils/trade.py
@@ -12,6 +12,7 @@ from models.item_modifier import ItemModifier
 from utils.config import RELEASE_URL, VERSION
 from utils.exceptions import InvalidAPIResponseException
 
+NINJA_BASES = []
 
 mod_list = []
 mod_list_dict_id = {}
@@ -183,19 +184,22 @@ def get_ninja_bases():
 
     Returns list[dict]
     """
-    query = requests.get("https://poe.ninja/api/data/itemoverview?league=Metamorph&type=BaseType&language=en")
-    tbases = query.json()
+    global NINJA_BASES
+    if not NINJA_BASES:
+        query = requests.get("https://poe.ninja/api/data/itemoverview?league=Metamorph&type=BaseType&language=en")
+        tbases = query.json()
 
-    bases = [
-        {
-            "base": b["baseType"],
-            "ilvl": b["levelRequired"],
-            "influence": b["variant"],
-            "corrupted": b["corrupted"],
-            "exalt": b["exaltedValue"],
-            "chaos": b["chaosValue"],
-        }
-        for b in tbases["lines"]
-    ]
+        NINJA_BASES = [
+            {
+                "base": b["baseType"],
+                "ilvl": b["levelRequired"],
+                "influence": b["variant"],
+                "corrupted": b["corrupted"],
+                "exalt": b["exaltedValue"],
+                "chaos": b["chaosValue"],
+                "type": b["itemType"]
+            }
+            for b in tbases["lines"]
+        ]
 
-    return bases
+    return NINJA_BASES

--- a/utils/trade.py
+++ b/utils/trade.py
@@ -12,12 +12,17 @@ from models.item_modifier import ItemModifier
 from utils.config import RELEASE_URL, VERSION
 from utils.exceptions import InvalidAPIResponseException
 
-NINJA_BASES = []
+ninja_bases = []
 
 mod_list = []
 mod_list_dict_id = {}
 mod_list_dict_text = {}
 
+def search_url(league: str) -> str:
+    return f"https://www.pathofexile.com/api/trade/search/{league}"
+
+def exchange_url(league: str) -> str:
+    return f"https://www.pathofexile.com/api/trade/exchange/{league}"
 
 def exchange_currency(query: dict, league: str) -> dict:
     """
@@ -26,7 +31,7 @@ def exchange_currency(query: dict, league: str) -> dict:
     :return results: return a JSON object with the amount of items found and a key to get
      item details
     """
-    results = requests.post(f"https://www.pathofexile.com/api/trade/exchange/{league}", json=query)
+    results = requests.post(exchange_url(league), json=query)
     return results.json()
 
 
@@ -37,7 +42,7 @@ def query_item(query: dict, league: str) -> dict:
     :return results: return a JSON object with the amount of items found and a key to get
      item details
     """
-    results = requests.post(f"https://www.pathofexile.com/api/trade/search/{league}", json=query)
+    results = requests.post(search_url(league), json=query)
     return results.json()
 
 
@@ -184,12 +189,12 @@ def get_ninja_bases():
 
     Returns list[dict]
     """
-    global NINJA_BASES
-    if not NINJA_BASES:
+    global ninja_bases
+    if not ninja_bases:
         query = requests.get("https://poe.ninja/api/data/itemoverview?league=Metamorph&type=BaseType&language=en")
         tbases = query.json()
 
-        NINJA_BASES = [
+        ninja_bases = [
             {
                 "base": b["baseType"],
                 "ilvl": b["levelRequired"],
@@ -202,4 +207,4 @@ def get_ninja_bases():
             for b in tbases["lines"]
         ]
 
-    return NINJA_BASES
+    return ninja_bases


### PR DESCRIPTION
* Introduce more specific Item subclasses, so we can more easily
  produce json for specific cases, like a Map or a Fragment, without
  as many if/elif branches required.
* Improve get_item_modifiers_by_* functions in utils/trade.
  These now fetch ItemModifier objects directly instead of returning
  the entire dict containing them and their keys.
* Include map iiq/iir/pack_size when parsing an item. Currently,
  use a dict to decide if we have an "other_type" to return.
* Now support map influences.
* Support all item influences by putting them into the Item influence
  list.
* Support + and - for numerical modifiers. We can have items that have -n mods in them, so we include + and - now in the mod's value. This works fine through search and should through the API as well.

We still have some edge cases when parsing here that need to be worked
out. Please see the multi-line comment with a copied item and check
the current code against it. We miss a few explicit mods in that case.

There are also some augmented mods we're doing nothing with, but I'm
not sure that's much of an issue.

Additionally, there are many debugging print messages included with this commit
that need to be removed before we PR into upstream.

Signed-off-by: Kevin Morris <kevr.gtalk@gmail.com>